### PR TITLE
Minor fixes to release drafter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,14 +1,20 @@
-name: Release Drafter
+name: release-drafter
 
 on:
   push:
+    # branches to consider in the event; optional, defaults to all
     branches:
       - $default-branch
+      - main
+      - master
+      - 'releases/**'
+      - 'stable/**'
 
 jobs:
   update_release_draft:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Apparently release drafter does not work well and I suspect the variable with default branch name is not expanded correctly by gha.