### PR TITLE
Update build-system requirement for setuptools-scm to >=7.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,7 @@
 [build-system]
 requires = [
-  "pip >= 19.3.1",
-  "setuptools >= 42",
-  "setuptools_scm[toml] >= 3.5.0",
-  "setuptools_scm_git_archive >= 1.1",
-  "wheel >= 0.33.6",
+  "setuptools >= 45",
+  "setuptools_scm[toml] >= 7.0.0",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,8 +56,7 @@ zip_safe = False
 
 # These are required during `setup.py` run:
 setup_requires =
-    setuptools_scm >= 1.15.0
-    setuptools_scm_git_archive >= 1.0
+    setuptools_scm[toml]>=7.0.0
 
 # These are required in actual runtime:
 install_requires =

--- a/setup.py
+++ b/setup.py
@@ -13,5 +13,5 @@ site.ENABLE_USER_SITE = "--user" in sys.argv[1:]
 if __name__ == "__main__":
     setuptools.setup(
         use_scm_version={"local_scheme": "no-local-version"},
-        setup_requires=["setuptools_scm[toml]>=3.5.0"],
+        setup_requires=["setuptools_scm[toml]>=7.0.0"],
     )


### PR DESCRIPTION
pyproject.toml:
Update build-system requirement for setuptools-scm to >=7.0.0, which obsoletes the use of setuptools-scm-git-archive.
Remove pip and wheel from build-system as they are not required in a PEP517 build setup using pypa/build and pypa/installer.

setup.{cfg,py}:
Update build-system requirement for setuptools-scm to >=7.0.0, which obsoletes the use of setuptools-scm-git-archive.