### PR TITLE
Don't strip newlines when ANSI text is sent to print()

### DIFF
--- a/src/enrich/console.py
+++ b/src/enrich/console.py
@@ -6,6 +6,7 @@ from typing import Any, TextIO
 
 import rich.console as rich_console
 from rich.ansi import AnsiDecoder
+from rich.containers import Lines
 from rich.file_proxy import FileProxy
 
 
@@ -48,8 +49,8 @@ class Console(rich_console.Console):
         if args and isinstance(args[0], str) and "\033" in args[0]:
             text = format(*args) + "\n"
             decoder = AnsiDecoder()
-            args = list(decoder.decode(text))  # type: ignore
-        super().print(*args, **kwargs)
+            args = Lines(decoder.decode(text))  # type: ignore[assignment]
+        super().print(args, **kwargs)
 
 
 # Based on Ansible implementation

--- a/src/enrich/console.py
+++ b/src/enrich/console.py
@@ -50,7 +50,9 @@ class Console(rich_console.Console):
             text = format(*args) + "\n"
             decoder = AnsiDecoder()
             args = Lines(decoder.decode(text))  # type: ignore[assignment]
-        super().print(args, **kwargs)
+            super().print(args, **kwargs)
+        else:
+            super().print(*args, **kwargs)
 
 
 # Based on Ansible implementation

--- a/test/test_console.py
+++ b/test/test_console.py
@@ -56,10 +56,10 @@ def test_console_soft_wrap() -> None:
 def test_console_print_ansi() -> None:
     """Validates that Console.print() with ANSI does not make break them."""
     console = Console(force_terminal=True, record=True, soft_wrap=True, redirect=True)
-    text = "\033[92mfuture is green!\033[0m"
+    text = "\033[92mfuture is green!\033[0m\nwowsers!"
     console.print(text)
     text_result = console.export_text(clear=False)
-    assert "future is green!" in text_result
+    assert "future is green!\nwowsers!" in text_result
     html_result = console.export_html()
     assert "#00ff00" in html_result
 


### PR DESCRIPTION
`AnsiDecoder.decode()` takes a single `str` and returns a sequence of `Text` split by newline. If this is used directly, newlines in the source will not be restored when sent to print().

Using `Lines` instead of `list` lets us indicate to Rich that these `Text` objects should be interspersed with newlines.

Ref https://github.com/Textualize/rich/blob/master/rich/ansi.py#L126